### PR TITLE
change name of administration spider to administrations, update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ There are currently five available scrapers, which should initially run in this 
 
 1. llp (legislative periods)
 2. persons (for instance [Rudolf Anschober](http://www.parlament.gv.at/WWER/PAD_00024/index.shtml))
-3. administration (also persons, but those that are/were in a a Regierung)
+3. administrations (also persons, but those that are/were in a a Regierung)
 4. pre_laws (for instance [Buchhaltungsagenturgesetz, Änderung (513/ME)](http://www.parlament.gv.at/PAKT/VHG/XXIV/ME/ME_00513/index.shtml))
 5. laws_initiatives (for instance [ÖBIB-Gesetz 2015 (458 d.B.)](http://www.parlament.gv.at/PAKT/VHG/XXV/I/I_00458/index.shtml))
 

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/administrations.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/administrations.py
@@ -40,7 +40,7 @@ class AdministrationsSpider(PersonsSpider):
 
     LLP = []
 
-    name = "administration"
+    name = "administrations"
     title = "Administrations (Regierungen) Spider"
     persons_scraped = []
 


### PR DESCRIPTION
AdministrationsSpider passte nicht zu den anderen:
- Name war Einzahl
- Name war nicht der Dateiname der .py Datei

Dieser PR passt das an, der name ist jetzt "administrations" statt vorher "administration", readme.md wurde angepasst, in den anderen docs stand er sogar als administrations drinnen
