### PR TITLE
allow llp based retrieval in pre_laws spider

### DIFF
--- a/offenesparlament/op_scraper/scraper/parlament/spiders/pre_laws.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/pre_laws.py
@@ -57,6 +57,12 @@ class PreLawsSpider(BaseSpider):
     def __init__(self, **kw):
         super(PreLawsSpider, self).__init__(**kw)
 
+        if 'llp' in kw:
+            try:
+                self.LLP = [int(kw['llp'])]
+            except:
+                pass
+
         # add at least a default URL for testing
         self.start_urls = self.get_urls()
 


### PR DESCRIPTION
pre_laws spider hatte keine möglichkeit llp anzugeben. dieser PR fügt das hinzu.
