### PR TITLE
this should fix #28

### DIFF
--- a/offenesparlament/offenesparlament/settings.py
+++ b/offenesparlament/offenesparlament/settings.py
@@ -47,7 +47,8 @@ class BaseConfig(Configuration):
         'django_extensions',
         'django_bootstrap_breadcrumbs',
         'import_export',
-        'jsonify'
+        'jsonify',
+        'djcelery',
     )
 
     MIDDLEWARE_CLASSES = (
@@ -148,7 +149,7 @@ class Dev(BaseConfig):
     DEBUG = True
     TEMPLATE_DEBUG = True
     BROKER_URL = 'amqp://offenesparlament:op_dev_qwerty@offenesparlament.vm:5672//'
-    CELERY_RESULT_BACKEND = 'amqp'
+    #CELERY_RESULT_BACKEND = 'amqp'
 
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 


### PR DESCRIPTION
djcelery was not in INSTALLED_APPS and overridden by amqp in dev-settings

please confirm this works with your installs (:

(btw: should a celery worker run by-default in vagrant?)
