### PR TITLE
Scraper für Ausschüsse

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,4 @@ Vagrant.configure("2") do |config|
     #, verbose: "vvv"
 
   end
-
-  config.ssh.insert_key = false
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,4 +40,6 @@ Vagrant.configure("2") do |config|
     #, verbose: "vvv"
 
   end
+
+  config.ssh.insert_key = false
 end

--- a/offenesparlament/bin/clear_db.sh
+++ b/offenesparlament/bin/clear_db.sh
@@ -1,1 +1,1 @@
-python remove_migrations.py && rm db.sqlite3 && python manage.py makemigrations && python manage.py migrate && python manage.py createsuperuser --email loki@fsinf.at --username admin
+python remove_migrations.py && rm -f db.sqlite3 && python manage.py makemigrations && python manage.py migrate && python manage.py createsuperuser --email loki@fsinf.at --username admin

--- a/offenesparlament/op_scraper/admin_views.py
+++ b/offenesparlament/op_scraper/admin_views.py
@@ -11,6 +11,7 @@ from op_scraper.scraper.parlament.spiders.petitions import PetitionsSpider
 from op_scraper.scraper.parlament.spiders.pre_laws import PreLawsSpider
 from op_scraper.scraper.parlament.spiders.persons import PersonsSpider
 from op_scraper.scraper.parlament.spiders.statement import StatementSpider
+from op_scraper.scraper.parlament.spiders.comittees import ComitteesSpider
 
 
 SPIDERS = {
@@ -42,6 +43,10 @@ SPIDERS = {
         'scraper': StatementSpider,
         'has_options': True
     },
+    'comittees': {
+        'scraper': ComitteesSpider,
+        'has_options': True
+    },
 }
 
 SPIDER_CHOICES = (
@@ -52,6 +57,7 @@ SPIDER_CHOICES = (
     ('laws', 'Gesetze'),
     ('petitions', 'Petitionen'),
     ('debates', 'Debatten und Statements'),
+    ('comittees', 'Ausschüsse')
 )
 
 from django import forms

--- a/offenesparlament/op_scraper/migrations/0001_initial.py
+++ b/offenesparlament/op_scraper/migrations/0001_initial.py
@@ -38,6 +38,7 @@ class Migration(migrations.Migration):
                 ('source_link', models.URLField(default=b'', max_length=255)),
                 ('nrbr', models.CharField(max_length=20)),
                 ('description', models.TextField(default=b'', blank=True)),
+                ('active', models.BooleanField(default=True)),
             ],
             bases=(models.Model, op_scraper.models.ParlIDMixIn),
         ),
@@ -75,7 +76,7 @@ class Migration(migrations.Migration):
                 ('title', models.CharField(max_length=255, null=True)),
                 ('debate_type', models.CharField(max_length=255, null=True)),
                 ('protocol_url', models.URLField(max_length=255, null=True)),
-                ('detail_url', models.URLField(max_length=255, null=True)),
+                ('detail_url', models.URLField(max_length=255, null=True, blank=True)),
                 ('nr', models.IntegerField(null=True)),
             ],
         ),
@@ -403,7 +404,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='law',
             name='legislative_period',
-            field=models.ForeignKey(to='op_scraper.LegislativePeriod'),
+            field=models.ForeignKey(blank=True, to='op_scraper.LegislativePeriod', null=True),
         ),
         migrations.AddField(
             model_name='law',
@@ -466,7 +467,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='comittee',
             name='laws',
-            field=models.ManyToManyField(related_name='comittees', null=True, to='op_scraper.Law', blank=True),
+            field=models.ManyToManyField(related_name='comittees', to='op_scraper.Law', blank=True),
         ),
         migrations.AddField(
             model_name='comittee',
@@ -506,6 +507,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='comittee',
-            unique_together=set([('parl_id', 'legislative_period')]),
+            unique_together=set([('parl_id', 'legislative_period', 'active')]),
         ),
     ]

--- a/offenesparlament/op_scraper/migrations/0001_initial.py
+++ b/offenesparlament/op_scraper/migrations/0001_initial.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations, models
 import phonenumber_field.modelfields
 import op_scraper.models
 import annoying.fields
@@ -27,6 +27,44 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('title', models.CharField(unique=True, max_length=255)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Comittee',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=511)),
+                ('parl_id', models.CharField(max_length=30)),
+                ('source_link', models.URLField(default=b'', max_length=255)),
+                ('nrbr', models.CharField(max_length=20)),
+                ('description', models.TextField(default=b'', blank=True)),
+            ],
+            bases=(models.Model, op_scraper.models.ParlIDMixIn),
+        ),
+        migrations.CreateModel(
+            name='ComitteeAgendaTopic',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('number', models.IntegerField()),
+                ('text', models.TextField()),
+                ('comment', models.CharField(max_length=255, null=True, blank=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='ComitteeMeeting',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('number', models.IntegerField()),
+                ('date', models.DateField()),
+            ],
+        ),
+        migrations.CreateModel(
+            name='ComitteeMembership',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('date_from', models.DateField()),
+                ('date_to', models.DateField(null=True, blank=True)),
+                ('comittee', models.ForeignKey(related_name='comittee_members', to='op_scraper.Comittee')),
             ],
         ),
         migrations.CreateModel(
@@ -395,6 +433,51 @@ class Migration(migrations.Migration):
             name='llp',
             field=models.ForeignKey(blank=True, to='op_scraper.LegislativePeriod', null=True),
         ),
+        migrations.AddField(
+            model_name='comitteemembership',
+            name='function',
+            field=models.ForeignKey(related_name='comittee_function', to='op_scraper.Function'),
+        ),
+        migrations.AddField(
+            model_name='comitteemembership',
+            name='person',
+            field=models.ForeignKey(related_name='comittee_memberships', to='op_scraper.Person'),
+        ),
+        migrations.AddField(
+            model_name='comitteemeeting',
+            name='agenda',
+            field=models.OneToOneField(related_name='comittee_meeting', null=True, to='op_scraper.Document'),
+        ),
+        migrations.AddField(
+            model_name='comitteemeeting',
+            name='comittee',
+            field=models.ForeignKey(related_name='comittee_meetings', to='op_scraper.Comittee'),
+        ),
+        migrations.AddField(
+            model_name='comitteeagendatopic',
+            name='law',
+            field=models.ForeignKey(related_name='agenda_topics', to='op_scraper.Law', null=True),
+        ),
+        migrations.AddField(
+            model_name='comitteeagendatopic',
+            name='meeting',
+            field=models.ForeignKey(related_name='agenda_topics', to='op_scraper.ComitteeMeeting'),
+        ),
+        migrations.AddField(
+            model_name='comittee',
+            name='laws',
+            field=models.ManyToManyField(related_name='comittees', null=True, to='op_scraper.Law', blank=True),
+        ),
+        migrations.AddField(
+            model_name='comittee',
+            name='legislative_period',
+            field=models.ForeignKey(blank=True, to='op_scraper.LegislativePeriod', null=True),
+        ),
+        migrations.AddField(
+            model_name='comittee',
+            name='parent_comittee',
+            field=models.ForeignKey(related_name='sub_comittees', blank=True, to='op_scraper.Comittee', null=True),
+        ),
         migrations.AlterUniqueTogether(
             name='subscription',
             unique_together=set([('user', 'content')]),
@@ -411,6 +494,18 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='law',
+            unique_together=set([('parl_id', 'legislative_period')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='comitteemeeting',
+            unique_together=set([('number', 'date', 'comittee')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='comitteeagendatopic',
+            unique_together=set([('number', 'meeting')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='comittee',
             unique_together=set([('parl_id', 'legislative_period')]),
         ),
     ]

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -768,3 +768,34 @@ class ComitteeMembership(models.Model):
     def __unicode__(self):
         return u'{}: {} des {} ({}-{})'\
             .format(self.person, self.function, self.comittee, self.date_from, self.date_to)
+
+
+class ComitteeMeeting(models.Model):
+    """
+    Meeting ("Sitzung") of a Comittee
+    """
+    number = models.IntegerField()
+    date = models.DateField()
+
+    # Relationships
+    comittee = models.ForeignKey(Comittee, related_name='comittee_meetings')
+    agenda = models.OneToOneField(Document, related_name='comittee_meeting')
+
+    class Meta:
+        unique_together = ("number", "date", "comittee")
+
+
+class ComitteeAgendaTopic(models.Model):
+    """
+    Agenda topic ("Tagesordnungspunkt") of a Comittee meeting
+    """
+    number = models.IntegerField()
+    text = models.CharField(max_length=255)
+    comment = models.CharField(max_length=255)
+
+    # Relationships
+    meeting = models.ForeignKey(Comittee, related_name='agenda_topics')
+    law = models.ForeignKey(Law, related_name='agenda_topics', null=True)
+
+    class Meta:
+        unique_together = ("number", "meeting")

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -745,7 +745,9 @@ class Comittee(models.Model, ParlIDMixIn):
     # Relationships
     legislative_period = models.ForeignKey(
         LegislativePeriod, blank=True, null=True)
-    laws = models.ManyToManyField(Law, related_name='comitees')
+    laws = models.ManyToManyField(Law, blank=True, null=True, related_name='comittees')
+    parent_comittee = models.ForeignKey(
+        "self", blank=True, null=True, related_name='sub_comittees')
 
     class Meta:
         unique_together = ("parl_id", "legislative_period")

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -735,7 +735,7 @@ class Comittee(models.Model, ParlIDMixIn):
     "Parlamentarischer Ausschuss"
     Comittee of either the Nationalrat or Bundesrat for a specific topic
     """
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=511)
     parl_id = models.CharField(max_length=30)
     source_link = models.URLField(max_length=255, default="")
     nrbr = models.CharField(max_length=20)

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -729,3 +729,42 @@ class DebateStatement(models.Model):
             self.index,
             self.doc_section,
             self.date)
+
+class Comittee(models.Model, ParlIDMixIn):
+    """
+    "Parlamentarischer Ausschuss"
+    Comittee of either the Nationalrat or Bundesrat for a specific topic
+    """
+    name = models.CharField(max_length=255)
+    parl_id = models.CharField(max_length=30)
+    source_link = models.URLField(max_length=255, default="")
+    nrbr = models.CharField(max_length=20)
+    description = models.CharField(max_length=1000, default="", blank=True)
+
+    # Relationships
+    legislative_period = models.ForeignKey(
+        LegislativePeriod, blank=True, null=True)
+
+    class Meta:
+        unique_together = ("parl_id", "legislative_period")
+
+    def __unicode__(self):
+        return u'{} [{}] in {}'\
+            .format(self.name, self.parl_id, self.legislative_period)
+
+
+class ComitteeMembership(models.Model):
+    """
+    Membership in a Comittee
+    """
+    date_from = models.DateField()
+    date_to = models.DateField(blank=True, null=True)
+
+    # Relationships
+    comittee = models.ForeignKey(Comittee, related_name='comittee_members')
+    person = models.ForeignKey(Person, related_name='comittee_memberships')
+    function = models.ForeignKey(Function, related_name='comittee_function')
+
+    def __unicode__(self):
+        return u'{}: {} des {} ({}-{})'\
+            .format(self.person, self.function, self.comittee, self.date_from, self.date_to)

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -741,16 +741,19 @@ class Comittee(models.Model, ParlIDMixIn):
     source_link = models.URLField(max_length=255, default="")
     nrbr = models.CharField(max_length=20)
     description = models.TextField(default="", blank=True)
+    active = models.BooleanField(default=True)
 
     # Relationships
     legislative_period = models.ForeignKey(
         LegislativePeriod, blank=True, null=True)
-    laws = models.ManyToManyField(Law, blank=True, null=True, related_name='comittees')
+    laws = models.ManyToManyField(Law, blank=True, related_name='comittees')
     parent_comittee = models.ForeignKey(
         "self", blank=True, null=True, related_name='sub_comittees')
 
     class Meta:
-        unique_together = ("parl_id", "legislative_period")
+        # NR comittees are unique by parl_id & legislative period
+        # BR comittees additionaly need active for uniqueness
+        unique_together = ("parl_id", "legislative_period", "active")
 
     def __unicode__(self):
         return u'{} [{}] in {}'\

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -730,6 +730,7 @@ class DebateStatement(models.Model):
             self.doc_section,
             self.date)
 
+
 class Comittee(models.Model, ParlIDMixIn):
     """
     "Parlamentarischer Ausschuss"
@@ -744,6 +745,7 @@ class Comittee(models.Model, ParlIDMixIn):
     # Relationships
     legislative_period = models.ForeignKey(
         LegislativePeriod, blank=True, null=True)
+    laws = models.ManyToManyField(Law, related_name='comitees')
 
     class Meta:
         unique_together = ("parl_id", "legislative_period")
@@ -790,7 +792,7 @@ class ComitteeAgendaTopic(models.Model):
     Agenda topic ("Tagesordnungspunkt") of a Comittee meeting
     """
     number = models.IntegerField()
-    text = models.CharField(max_length=1000)
+    text = models.TextField()
     comment = models.CharField(max_length=255, null=True, blank=True)
 
     # Relationships

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -779,7 +779,7 @@ class ComitteeMeeting(models.Model):
 
     # Relationships
     comittee = models.ForeignKey(Comittee, related_name='comittee_meetings')
-    agenda = models.OneToOneField(Document, related_name='comittee_meeting')
+    agenda = models.OneToOneField(Document, related_name='comittee_meeting', null=True)
 
     class Meta:
         unique_together = ("number", "date", "comittee")
@@ -791,10 +791,10 @@ class ComitteeAgendaTopic(models.Model):
     """
     number = models.IntegerField()
     text = models.CharField(max_length=255)
-    comment = models.CharField(max_length=255)
+    comment = models.CharField(max_length=255, null=True, blank=True)
 
     # Relationships
-    meeting = models.ForeignKey(Comittee, related_name='agenda_topics')
+    meeting = models.ForeignKey(ComitteeMeeting, related_name='agenda_topics')
     law = models.ForeignKey(Law, related_name='agenda_topics', null=True)
 
     class Meta:

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -805,4 +805,4 @@ class ComitteeAgendaTopic(models.Model):
     law = models.ForeignKey(Law, related_name='agenda_topics', null=True)
 
     class Meta:
-        unique_together = ("number", "meeting")
+        unique_together = ("text", "meeting")

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -803,6 +803,3 @@ class ComitteeAgendaTopic(models.Model):
     # Relationships
     meeting = models.ForeignKey(ComitteeMeeting, related_name='agenda_topics')
     law = models.ForeignKey(Law, related_name='agenda_topics', null=True)
-
-    class Meta:
-        unique_together = ("text", "meeting")

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -739,7 +739,7 @@ class Comittee(models.Model, ParlIDMixIn):
     parl_id = models.CharField(max_length=30)
     source_link = models.URLField(max_length=255, default="")
     nrbr = models.CharField(max_length=20)
-    description = models.CharField(max_length=1000, default="", blank=True)
+    description = models.TextField(default="", blank=True)
 
     # Relationships
     legislative_period = models.ForeignKey(

--- a/offenesparlament/op_scraper/models.py
+++ b/offenesparlament/op_scraper/models.py
@@ -790,7 +790,7 @@ class ComitteeAgendaTopic(models.Model):
     Agenda topic ("Tagesordnungspunkt") of a Comittee meeting
     """
     number = models.IntegerField()
-    text = models.CharField(max_length=255)
+    text = models.CharField(max_length=1000)
     comment = models.CharField(max_length=255, null=True, blank=True)
 
     # Relationships

--- a/offenesparlament/op_scraper/scraper/parlament/resources/extractors/comittee.py
+++ b/offenesparlament/op_scraper/scraper/parlament/resources/extractors/comittee.py
@@ -224,11 +224,17 @@ class COMITTEE:
 
     class LAWS(SingleExtractor):
 
-        XPATH = '//*[@id="tab-Verhandlungsgegenstaende"]/following-sibling::div/ul/li/a'
+        # Verhandlungsgegenstaende
+        XPATH_LAWS = '//*[@id="tab-Verhandlungsgegenstaende"]/following-sibling::div/ul/li/a'
+        # Veroeffentlichungen
+        XPATH_REPORTS = '//*[@id="tab-VeroeffentlichungenBerichte"]/following-sibling::div/ul/li/a'
 
         @classmethod
         def xt(cls, response):
-            raw_laws = response.xpath(cls.XPATH)
+            raw_laws = response.xpath(cls.XPATH_LAWS)
+            raw_reports = response.xpath(cls.XPATH_REPORTS)
+
+            raw_laws = raw_laws + raw_reports
 
             laws = []
 

--- a/offenesparlament/op_scraper/scraper/parlament/resources/extractors/comittee.py
+++ b/offenesparlament/op_scraper/scraper/parlament/resources/extractors/comittee.py
@@ -1,0 +1,140 @@
+import datetime
+from django.utils.html import remove_tags
+from scrapy import Selector
+
+from parlament.resources.extractors import SingleExtractor
+from parlament.resources.util import _clean
+
+from parlament.settings import BASE_HOST
+
+import time
+import datetime
+
+# import the logging library
+import logging
+
+# Get an instance of a logger
+logger = logging.getLogger(__name__)
+
+
+class COMITTEE:
+
+
+    class MEMBERSHIP(SingleExtractor):
+
+        #XPATH = '//*[@id="content"]/div[3]/div[4]/h3'
+        XPATH = '//*[@id="tab-Ausschuesse"]/following-sibling::h3'
+
+        @classmethod
+        def xt(cls, response):
+            raw_memberships = response.xpath(cls.XPATH)
+
+            memberships = []
+
+            for raw_membership in raw_memberships:
+                raw_llp = raw_membership.xpath('a[1]/text()').extract()[1]
+                nrbr = u'Nationalrat'
+                comittee_llp = None
+                if nrbr in raw_llp:
+                    comittee_llp = raw_llp.split()[-2][:-1]
+                else:
+                    nrbr = u'Bundesrat'
+
+                tablerows = raw_membership.xpath('following-sibling::div[1]/table[1]/tbody/tr').extract()
+
+                last_position = u''
+                for row in tablerows:
+                    row_sel = Selector(text=row)
+
+                    raw_position = row_sel.xpath('//td[@class="biogr_am_funktext"]/text()').extract()
+                    if len(raw_position) > 0:
+                        position = _clean(raw_position[0])
+                        position = cls.standardize_position(position)
+                        last_position = position
+                    else:
+                        position = last_position
+
+                    raw_comittee_link = row_sel.xpath('//td[@class="biogr_am_ausschuss"]/a/@href').extract()
+                    if raw_comittee_link:
+                        comittee_link = raw_comittee_link[0]
+                        raw_parl_id = comittee_link.split('/')[-2]
+                        raw_parl_id = raw_parl_id.split('_')
+                        parl_id_type = raw_parl_id[0]
+                        parl_id_number = int(raw_parl_id[1])
+                        comittee_parl_id = u'({}/{})'.format(parl_id_number, parl_id_type)
+                        comittee_link = "{}/{}".format(BASE_HOST, comittee_link)
+                    else:
+                        comittee_link = u''
+                        comittee_parl_id = u''
+
+                    raw_comitee_name = row_sel.xpath('//td[@class="biogr_am_ausschuss"]/a/text()').extract()
+                    if len(raw_comitee_name) > 0:
+                        comittee_name = _clean(raw_comitee_name[0])
+                    else:
+                        raw_comitee_name = row_sel.xpath('//td[@class="biogr_am_ausschuss"]/text()').extract()
+                        if len(raw_comitee_name) > 0:
+                            comittee_name = _clean(raw_comitee_name[0])
+                        else:
+                            comittee_name = u''
+
+                    raw_dates = row_sel.xpath('//td[@class="biogr_am_vonbis"]/text()').extract()[0]
+                    if raw_dates:
+                        raw_dates = _clean(raw_dates)
+                        # \u2013 == - (dash)
+                        raw_dates = raw_dates.split(u'\u2013')
+                        raw_from = raw_dates[0]
+                        if raw_from is not u'':
+                            raw_from = time.strptime(raw_from, '%d.%m.%Y')
+                            date_from = datetime.datetime.fromtimestamp(time.mktime(raw_from))
+                        else:
+                            date_from = None
+
+                        raw_to = raw_dates[0]
+                        if raw_from is not u'':
+                            raw_to = time.strptime(raw_to, '%d.%m.%Y')
+                            date_to = datetime.datetime.fromtimestamp(time.mktime(raw_to))
+                        else:
+                            date_to = None
+
+                    memberships.append({
+                        'comittee':
+                            {
+                                'name': comittee_name,
+                                'parl_id': comittee_parl_id,
+                                'nrbr': nrbr,
+                                'llp': comittee_llp,
+                                'source_link': comittee_link
+                            },
+                        'position': position,
+                        'from': date_from,
+                        'to': date_to
+                    })
+
+            return memberships
+
+        @classmethod
+        def standardize_position(cls, position):
+
+            # Mapping between gendered comitee positions (as written on the parliament website)
+            # and standardized positions
+            comittee_positions = {
+                u'Obfrau': u'Obfrau/Obmann',
+                u'Obmann': u'Obfrau/Obmann',
+                u'Obfraustellvertreterin': u'ObfraustellvertreterIn/ObmannstellverteterIn',
+                u'Obmannstellvertreterin': u'ObfraustellvertreterIn/ObmannstellverteterIn',
+                u'Obfraustellvertreter': u'ObfraustellvertreterIn/ObmannstellverteterIn',
+                u'Obfraustellvertreterin': u'ObfraustellvertreterIn/ObmannstellverteterIn',
+                u'Vorsitzende': u'Vorsitzende/Vorsitzender',
+                u'Vorsitzender': u'Vorsitzende/Vorsitzender',
+                u'Schriftf\xfchrerin': u'Schriftf\xfchrerIn',
+                u'Schriftf\xfchrer': u'Schriftf\xfchrerIn',
+                u'Stellvertretende Ausschussvorsitzende':
+                    u'Stellvertretende Ausschussvorsitzende/Stellvertretender Ausschussvorsitzender',
+                u'Stellvertretende Ausschussvorsitzende':
+                    u'Stellvertretende Ausschussvorsitzende/Stellvertretender Ausschussvorsitzender'
+            }
+
+            if position in comittee_positions:
+                return comittee_positions[position]
+            else:
+                return position

--- a/offenesparlament/op_scraper/scraper/parlament/resources/extractors/comittee.py
+++ b/offenesparlament/op_scraper/scraper/parlament/resources/extractors/comittee.py
@@ -30,10 +30,11 @@ class COMITTEE:
                 raw_parl_id = splitted_url[-2]
                 if len(raw_parl_id) > 1:
                     raw_parl_id = raw_parl_id.split('_')
-                    parl_id_type = raw_parl_id[0]
-                    parl_id_number = int(raw_parl_id[1])
-                    parl_id = u'({}/{})'.format(parl_id_number, parl_id_type)
-                    return llp, parl_id
+                    if len(raw_parl_id) > 1:
+                        parl_id_type = raw_parl_id[0]
+                        parl_id_number = int(raw_parl_id[1])
+                        parl_id = u'({}/{})'.format(parl_id_number, parl_id_type)
+                        return llp, parl_id
 
         return u'', u''
 
@@ -157,9 +158,6 @@ class COMITTEE:
                     else:
                         topic_number = 0
 
-                    if topic_number == 0:
-                        continue  # not a TOP -> ignore row
-
                     raw_topic_text = raw_row.xpath('td[2]/text()').extract()
 
                     if len(raw_topic_text) > 0:
@@ -176,23 +174,21 @@ class COMITTEE:
                     else:
                         topic_comment = u''
 
-                    raw_topic_law_id = raw_row.xpath('td[2]/a/text()').extract()
+                    raw_topic_law_text = raw_row.xpath('td[2]/a/text()').extract()
 
-                    if len(raw_topic_law_id) > 0:
-                        topic_law_id = u'({})'.format(raw_topic_law_id[0])
+                    if len(raw_topic_law_text) > 0:
+                        topic_law_text = u'({})'.format(raw_topic_law_text[0])
                     else:
-                        topic_law_id = u''
+                        topic_law_text = u''
+
+                    topic_text = u'{} {}'.format(topic_text,topic_law_text)
 
                     raw_topic_law_link = raw_row.xpath('td[2]/a/@href').extract()
 
                     if len(raw_topic_law_link) > 0:
-                        raw_topic_law_link_splitted = raw_topic_law_link[0].split('/')
-                        if len(raw_topic_law_link_splitted) > 3:
-                            topic_law_llp = raw_topic_law_link_splitted[3]
-                        else:
-                            topic_law_llp = u''
+                        topic_law_llp, topic_law_id = COMITTEE.url_to_parlid(raw_topic_law_link[0])
                     else:
-                        topic_law_llp = u''
+                        topic_law_llp, topic_law_id = u'', u''
 
                     if topic_law_id != u'':
                         topic_law = {

--- a/offenesparlament/op_scraper/scraper/parlament/resources/extractors/comittee.py
+++ b/offenesparlament/op_scraper/scraper/parlament/resources/extractors/comittee.py
@@ -268,6 +268,23 @@ class COMITTEE:
 
             return laws
 
+    class ACTIVE(SingleExtractor):
+
+        XPATH = '//*[@id="tab-Sitzungsueberblick"]/following-sibling::table/tbody/tr'
+
+        @classmethod
+        def xt(cls, response):
+            rows = response.xpath(cls.XPATH)
+
+            for row in rows:
+                raw_active = row.xpath('td[2]/text()').extract()
+                if len(raw_active) > 0:
+                    active = _clean(raw_active[0])
+                    if active == u'Aufl\xf6sung':
+                        return False
+
+            return True
+
     class MEMBERSHIP(SingleExtractor):
 
         XPATH = '//*[@id="tab-Ausschuesse"]/following-sibling::h3'

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
@@ -193,7 +193,6 @@ class ComitteesSpider(BaseSpider):
                     law_item = None
 
                 agenda_topic_data = {
-                    'text': topic['text'],
                     'comment': topic['comment'],
                     'law': law_item,
                 }
@@ -201,6 +200,7 @@ class ComitteesSpider(BaseSpider):
                 agenda_topic_item, agenda_topic_created = ComitteeAgendaTopic.objects.update_or_create(
                     number=topic['number'],
                     meeting=meeting_item,
+                    text=topic['text'],
                     defaults=agenda_topic_data,
                 )
 

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
@@ -104,9 +104,13 @@ class ComitteesSpider(BaseSpider):
         if llp is not None:
             nrbr = 'Nationalrat'
             legislative_period = LegislativePeriod.objects.get(roman_numeral=llp)
+            # NR comittees are "active" if they are in the current LLP
+            active = (legislative_period == LegislativePeriod.objects.get_current())
         else:
             nrbr = 'Bundesrat'
             legislative_period = None
+            # BR comittees are active if they are not "aufgelöst"
+            active = COMITTEE.ACTIVE.xt(response)
 
         # main-comittee parl_id starts with the number 1
         # sub-comittees parl_id start  with the number 2
@@ -134,7 +138,8 @@ class ComitteesSpider(BaseSpider):
             'description': description,
             'name': name,
             'source_link': response.url,
-            'parent_comittee': parent_comitee
+            'parent_comittee': parent_comitee,
+            'active': active
         }
 
         try:
@@ -167,7 +172,7 @@ class ComitteesSpider(BaseSpider):
             logtext = u"Scraping meeting no. {} of {} on {}".format(
                 red(meeting['number']),
                 magenta(name),
-                green(meeting['date']),
+                green(str(meeting['date'].date())),
             )
             log.msg(logtext, level=log.INFO)
 

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
@@ -44,6 +44,7 @@ class ComitteesSpider(BaseSpider):
     }
 
     name = "comittees"
+    title = "Comittees Spider"
 
     def __init__(self, **kw):
         super(ComitteesSpider, self).__init__(**kw)
@@ -118,6 +119,15 @@ class ComitteesSpider(BaseSpider):
         else:
             parent_comitee = None
 
+        # Log our progress
+        logtext = u"Scraping {} with id {}, LLP {} @ {}".format(
+            red(name),
+            magenta(u"[{}]".format(parl_id)),
+            green(str(llp)),
+            blue(response.url)
+        )
+        log.msg(logtext, level=log.INFO)
+
         description = COMITTEE.DESCRIPTION.xt(response)
 
         comittee_data = {
@@ -153,6 +163,14 @@ class ComitteesSpider(BaseSpider):
                 'agenda': agenda_item
             }
 
+            # Log our progress
+            logtext = u"Scraping meeting no. {} of {} on {}".format(
+                red(meeting['number']),
+                magenta(name),
+                green(meeting['date']),
+            )
+            log.msg(logtext, level=log.INFO)
+
             meeting_item, meeting_created = ComitteeMeeting.objects.update_or_create(
                 number=meeting['number'],
                 date=meeting['date'],
@@ -185,10 +203,17 @@ class ComitteesSpider(BaseSpider):
         laws_and_reports = COMITTEE.LAWS.xt(response)
 
         for law in laws_and_reports:
+            # Log our progress
+            logtext = u"Adding law with id {}, LLP {} to {}".format(
+                magenta(u"[{}]".format(law['parl_id'])),
+                green(law['llp']),
+                blue(name)
+            )
+            log.msg(logtext, level=log.INFO)
+
             law_item = self.parse_law(law)
             if law_item is not None:
                 comittee_laws.append(law_item)
-
 
         comittee_item.laws.add(*comittee_laws)
         comittee_item.save()

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+import scrapy
+
+from ansicolor import red
+from ansicolor import cyan
+from ansicolor import green
+from ansicolor import blue
+from ansicolor import magenta
+
+import feedparser
+import roman
+from urllib import urlencode
+
+from scrapy import log
+
+from parlament.spiders import BaseSpider
+from parlament.resources.extractors.comittee import *
+
+from parlament.settings import BASE_HOST
+from parlament.resources.util import _clean
+
+from op_scraper.models import Comittee
+
+
+class ComitteesSpider(BaseSpider):
+    BASE_URL = "{}/{}".format(BASE_HOST, "PAKT/AUS/filter.psp")
+
+    URLOPTIONS = {
+        'view': 'RSS',
+        'jsMode': 'RSS',
+        'xdocumentUri': '/PAKT/AUS/index.shtml',
+        'NRBR': '',
+        'anwenden': 'Anwenden',
+        'BBET': '',
+        'SUCH': '',
+        'listeId': '109',
+        'FBEZ': 'FP_009',
+        'UA': 'J',
+    }
+
+    name = "comittees"
+
+    def __init__(self, **kw):
+        super(ComitteesSpider, self).__init__(**kw)
+
+        if 'llp' in kw:
+            try:
+                self.LLP = [int(kw['llp'])]
+            except:
+                pass
+
+        # add at least a default URL for testing
+        self.start_urls = self.get_urls()
+
+        self.cookies_seen = set()
+        self.idlist = {}
+
+    def get_urls(self):
+        """
+        Returns a list of URLs to scrape
+        """
+        urls = []
+        # NR comittees are LLP based
+        if self.LLP:
+            for i in self.LLP:
+                roman_numeral = roman.toRoman(i)
+                options = self.URLOPTIONS.copy()
+                options['GP'] = roman_numeral
+                options['NRBR'] = 'NR'
+                url_options = urlencode(options)
+                url_llp = "{}?{}".format(self.BASE_URL, url_options)
+                rss = feedparser.parse(url_llp)
+
+                print "GP {}: NR: {} Comittees".format(
+                    roman_numeral, len(rss['entries']))
+                urls = urls + [entry['link'] for entry in rss['entries']]
+
+        # BR comittees are not LLP based
+        # TODO: BR comittee URLs
+
+        return urls
+
+    def parse(self, response):
+        parl_id = COMITTEE.url_to_parlid(response.url)
+        llp = COMITTEE.LLP.xt(response)
+        name = COMITTEE.NAME.xt(response)
+        description = COMITTEE.DESCRIPTION.xt(response)
+
+
+        if llp is not None:
+            nrbr = 'Nationalrat'
+        else:
+            nrbr = 'Bundesrat'
+

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
@@ -80,8 +80,17 @@ class ComitteesSpider(BaseSpider):
                     roman_numeral, len(rss['entries']))
                 urls = urls + [entry['link'] for entry in rss['entries']]
 
-        # BR comittees are not LLP based
-        # TODO: BR comittee URLs
+        # AKT = aktiv, AUF = aufgeloest
+        for aktauf in ['AKT','AUF']:
+            options['NRBR'] = 'BR'
+            options['R_AKTAUF'] = aktauf
+            url_options = urlencode(options)
+            url_br = "{}?{}".format(self.BASE_URL, url_options)
+            rss = feedparser.parse(url_br)
+
+            print "BR {}: {} Comittees".format(
+                aktauf, len(rss['entries']))
+            urls = urls + [entry['link'] for entry in rss['entries']]
 
         return urls
 

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
@@ -224,9 +224,9 @@ class ComitteesSpider(BaseSpider):
         comittee_item.save()
 
     def parse_law(self, law_dict):
-        if law_dict['llp'] != u'' and law_dict['llp'] != u'BR':
+        try:
             law_legislative_period = LegislativePeriod.objects.get(roman_numeral=law_dict['llp'])
-        else:
+        except LegislativePeriod.DoesNotExist:
             law_legislative_period = None
 
         try:

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
@@ -20,7 +20,11 @@ from parlament.settings import BASE_HOST
 from parlament.resources.util import _clean
 
 from op_scraper.models import Comittee
+from op_scraper.models import ComitteeMeeting
+from op_scraper.models import ComitteeAgendaTopic
 from op_scraper.models import LegislativePeriod
+from op_scraper.models import Document
+from op_scraper.models import Law
 
 
 class ComitteesSpider(BaseSpider):
@@ -99,6 +103,7 @@ class ComitteesSpider(BaseSpider):
         comittee_data = {
             'description': description,
             'name': name,
+            'source_link': response.url
         }
 
         try:
@@ -111,3 +116,49 @@ class ComitteesSpider(BaseSpider):
         except:
             import ipdb
             ipdb.set_trace()
+
+        meetings = COMITTEE.MEETINGS.xt(response)
+
+        for meeting in meetings:
+            agenda_data = meeting['agenda']
+            if agenda_data is not None:
+                agenda_item, agenda_created = Document.objects.get_or_create(**agenda_data)
+            else:
+                agenda_item = None
+
+            meeting_data = {
+                'agenda': agenda_item
+            }
+
+            meeting_item, meeting_created = ComitteeMeeting.objects.update_or_create(
+                number=meeting['number'],
+                date=meeting['date'],
+                comittee=comittee_item,
+                defaults=meeting_data
+            )
+
+            for topic in meeting['topics']:
+                if topic['law'] is not None:
+                    law = topic['law']
+                    if law['llp'] != u'':
+                        law_legislative_period = LegislativePeriod.objects.get(roman_numeral=law['llp'])
+                    else:
+                        law_legislative_period = None
+                    try:
+                        law_item = Law.objects.get(legislative_period=law_legislative_period,parl_id=law['parl_id'])
+                    except Law.DoesNotExist:
+                        law_item = None
+                else:
+                    law_item = None
+
+                agenda_topic_data = {
+                    'text': topic['text'],
+                    'comment': topic['comment'],
+                    'law': law_item,
+                }
+
+                agenda_topic_item, agenda_topic_created = ComitteeAgendaTopic.objects.update_or_create(
+                    number=topic['number'],
+                    meeting=meeting_item,
+                    defaults=agenda_topic_data,
+                )


### PR DESCRIPTION
Der Scraper ist den Anforderungen (Code-Bounty Scraper Ausschüsse & Ausschuss-Details) entsprechend mal fertig. Getestet ist er auch, Fehler sind mir keine aufgefallen.

Ein paar kurze Anmerkungen:
- Scraping von Ausschussmitgliedschaften passiert durch einer Erweiterung des PersonsSpider
- Wie vor kurzem per Mail geschrieben versteckt das Parlament hin & wieder interessante Informationen in Tagesordnungen ohne die Punkte als Tagesordnungspunkt zu deklarieren. Ich werde schauen das zumindest noch die "Laws" aus solchen Tagesordnungspunkten hinzukommen.
- Wie am HackDay besprochen, existieren viele der behandelten Dokumente (noch) nicht in der Datenbank (zB Entschließungsanträge, Ausschussberichte, EU related Verhandlungsgegenstände). Dafür muss entweder der laws_initiatives scraper erweitert werden, oder ein zusätzlicher Scraper geschrieben werden.
- Die Tabs Veröffentlichungen & Verhandlungsgegenstände befüllen die Laws referenz im Comitteee Model. Ebenso werden dort bei TOPs gescrapte Laws reingesteckt.
- Doku wird nachgereicht, zuerst wird mal der PetitionsScraper dokumentiert :)
