### PR TITLE
fix broken comittee scraper, workaround complicated BR comittees

### DIFF
--- a/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/comittees.py
@@ -87,16 +87,16 @@ class ComitteesSpider(BaseSpider):
                 urls = urls + [entry['link'] for entry in rss['entries']]
 
         # AKT = aktiv, AUF = aufgeloest
-        for aktauf in ['AKT', 'AUF']:
-            options['NRBR'] = 'BR'
-            options['R_AKTAUF'] = aktauf
-            url_options = urlencode(options)
-            url_br = "{}?{}".format(self.BASE_URL, url_options)
-            rss = feedparser.parse(url_br)
+        #for aktauf in ['AKT', 'AUF']:
+        #    options['NRBR'] = 'BR'
+        #    options['R_AKTAUF'] = aktauf
+        #    url_options = urlencode(options)
+        #    url_br = "{}?{}".format(self.BASE_URL, url_options)
+        #    rss = feedparser.parse(url_br)
 
-            print "BR {}: {} Comittees".format(
-                aktauf, len(rss['entries']))
-            urls = urls + [entry['link'] for entry in rss['entries']]
+        #    print "BR {}: {} Comittees".format(
+        #        aktauf, len(rss['entries']))
+        #    urls = urls + [entry['link'] for entry in rss['entries']]
 
         return urls
 
@@ -104,16 +104,15 @@ class ComitteesSpider(BaseSpider):
         # Parse
         parl_id = COMITTEE.url_to_parlid(response.url)[1]
         ts = GENERIC.TIMESTAMP.xt(response)
-        llp = COMITTEE.LLP.xt(response)
+        LLP = COMITTEE.LLP.xt(response)
         name = COMITTEE.NAME.xt(response)
 
-        if llp is not None:
+        if LLP is not None:
             nrbr = 'Nationalrat'
             legislative_period = LegislativePeriod.objects.get(
-                roman_numeral=llp)
-            # NR comittees are "active" if they are in the current LLP
-            active = (
-                legislative_period == LegislativePeriod.objects.get_current())
+                roman_numeral=LLP)
+            # NR comittees are always "active", only BR comittees are either active or inactive
+            active = True
         else:
             nrbr = 'Bundesrat'
             legislative_period = None
@@ -154,7 +153,6 @@ class ComitteesSpider(BaseSpider):
             'name': name,
             'source_link': response.url,
             'parent_comittee': parent_comitee,
-            'active': active,
             'ts': ts
         }
 
@@ -163,6 +161,7 @@ class ComitteesSpider(BaseSpider):
                 parl_id=parl_id,
                 legislative_period=legislative_period,
                 nrbr=nrbr,
+                active=active,
                 defaults=comittee_data
             )
         except:

--- a/offenesparlament/op_scraper/scraper/parlament/spiders/persons.py
+++ b/offenesparlament/op_scraper/scraper/parlament/spiders/persons.py
@@ -350,54 +350,55 @@ class PersonsSpider(BaseSpider):
 
             for m in memberships:
                 comittee = m['comittee']
-                if comittee['legislative_period'] is not None:
-                    llp = LegislativePeriod.objects.get(
-                        roman_numeral=comittee['legislative_period'])
-                    comittee['legislative_period'] = llp
+                if comittee['nrbr'] == u'Nationalrat':
+                    if comittee['legislative_period'] is not None:
+                        llp = LegislativePeriod.objects.get(
+                            roman_numeral=comittee['legislative_period'])
+                        comittee['legislative_period'] = llp
 
-                comittee_item, created_comittee = Comittee.objects.update_or_create(
-                    parl_id=comittee['parl_id'],
-                    nrbr=comittee['nrbr'],
-                    legislative_period=comittee['legislative_period'],
-                    # source_link=comittee['source_link'],
-                    active=comittee[
-                        'active'] if 'active' in comittee else True,
-                    defaults=comittee)
-                if created_comittee:
-                    self.logger.info(u"Created comittee {}".format(
-                        green(u"[{}]".format(comittee))
-                    ))
+                    comittee_item, created_comittee = Comittee.objects.update_or_create(
+                        parl_id=comittee['parl_id'],
+                        nrbr=comittee['nrbr'],
+                        legislative_period=comittee['legislative_period'],
+                        # source_link=comittee['source_link'],
+                        active=comittee[
+                            'active'] if 'active' in comittee else True,
+                        defaults=comittee)
+                    if created_comittee:
+                        self.logger.info(u"Created comittee {}".format(
+                            green(u"[{}]".format(comittee))
+                        ))
 
-                function_data = {
-                    'title': m['function'],
-                    'short': m['function']
-                }
+                    function_data = {
+                        'title': m['function'],
+                        'short': m['function']
+                    }
 
-                function_item, created_function = Function.objects.get_or_create(
-                    **function_data)
-                if created_function:
-                    self.logger.info(u"Created function {}".format(
-                        green(u"[{}]".format(function_item))
-                    ))
+                    function_item, created_function = Function.objects.get_or_create(
+                        **function_data)
+                    if created_function:
+                        self.logger.info(u"Created function {}".format(
+                            green(u"[{}]".format(function_item))
+                        ))
 
-                membership_data = {
-                    'date_from': m['date_from'],
-                    'comittee': comittee_item,
-                    'person': person_item,
-                    'function': function_item
-                }
+                    membership_data = {
+                        'date_from': m['date_from'],
+                        'comittee': comittee_item,
+                        'person': person_item,
+                        'function': function_item
+                    }
 
-                membership_item, created_membership = ComitteeMembership.objects.update_or_create(
-                    defaults={
-                        'date_to': m['date_to']
-                    },
-                    **membership_data
-                )
+                    membership_item, created_membership = ComitteeMembership.objects.update_or_create(
+                        defaults={
+                            'date_to': m['date_to']
+                        },
+                        **membership_data
+                    )
 
-                if created_membership:
-                    self.logger.info(u"Created membership {}".format(
-                        green(u"[{}]".format(membership_item))
-                    ))
+                    if created_membership:
+                        self.logger.info(u"Created membership {}".format(
+                            green(u"[{}]".format(membership_item))
+                        ))
 
         except Exception as error:
             self.logger.info(


### PR DESCRIPTION
- Fixes bug #104 (llp in comittes scraper was written in small letters, Loki expected it to be big letters and broke it when fixing some unicode stuff :) )
- Tries to fix bug #47 (by making NR comittees more consistent, they are now always active & by disabling BR comittees [no time to fix them atm, they require a much more carefull handling])
