### PR TITLE
Statement: fixes page-numbering

### DIFF
--- a/offenesparlament/op_scraper/scraper/parlament/resources/extractors/statement.py
+++ b/offenesparlament/op_scraper/scraper/parlament/resources/extractors/statement.py
@@ -227,7 +227,7 @@ class DOCSECTIONS(MultiExtractor):
             res['ref_timestamp'] = current_timestamp
             res['time_start'] = min(timestamps) if len(timestamps) else None
             res['time_end'] =  max(timestamps) if len(timestamps) else None
-            res['page_start'] =  min(pages) if len(pages) else current_maxpage
+            res['page_start'] =  min(pages) - 1 if len(pages) else current_maxpage
             res['page_end'] = max(pages) if len(pages) else current_maxpage
 
             sections.append(res)


### PR DESCRIPTION
A page/break inside a section means the section started one page before that - hence minimum page nr found, minus 1.

This should improve the accuracy of page_start in DebateStatement in many cases.
