### PR TITLE
set email input type to email #94

### DIFF
--- a/offenesparlament/offenesparlament/templates/petition_signatures.html
+++ b/offenesparlament/offenesparlament/templates/petition_signatures.html
@@ -19,7 +19,7 @@
         {% csrf_token %}
         <input type="hidden" name="subscription_url" value="{{ request.build_absolute_uri }}search">
         <label for="email">Email: </label>
-        <input id="input_email" type="text" name="email" value=""/>
+        <input id="input_email" type="email" name="email" value=""/>
         <input type="submit" value="OK"/>
     </form>
     <!-- EXAMPLE FORM FOR SEARCH/PAGE SUBSCRIPTION -->


### PR DESCRIPTION
I haven't tested how it actually looks in the frontend.

> email: HTML5
> A field for editing an e-mail address. The input value is validated to contain either the empty string or a single valid e-mail address before submitting. The :valid and :invalid CSS pseudo-classes are applied as appropriate.

– https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

We could also set it to `required`.

> required HTML5
> This attribute specifies that the user must fill in a value before submitting a form. It cannot be used when the type attribute is hidden, image, or a button type (submit, reset, or button). The :optional and :required CSS pseudo-classes will be applied to the field as appropriate.

– https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
